### PR TITLE
[codex] Add visible updater helper

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,9 +211,10 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --tag "$GITHUB_REF_NAME" \
             --out release-assets/wisp-release-manifest.json \
+            --checksums-out release-assets/SHA256SUMS.txt \
             $(find release-assets -type f ! -name "wisp-release-manifest.json" -print)
 
       - name: Upload release manifest
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "$GITHUB_REF_NAME" release-assets/wisp-release-manifest.json --clobber
+        run: gh release upload "$GITHUB_REF_NAME" release-assets/wisp-release-manifest.json release-assets/SHA256SUMS.txt --clobber

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,9 @@ jobs:
 
       - name: Package Windows artifact
         shell: pwsh
-        run: Compress-Archive -Path dist\Wisp -DestinationPath "dist\Wisp-${{ github.ref_name }}-windows-x64.zip" -Force
+        run: |
+          $safeRef = $env:GITHUB_REF_NAME -replace '[\\/]', '-'
+          Compress-Archive -Path dist\Wisp -DestinationPath "dist\Wisp-$safeRef-windows-x64.zip" -Force
 
       - name: Upload Windows release asset
         if: startsWith(github.ref, 'refs/tags/v')
@@ -109,7 +111,9 @@ jobs:
         run: ./tools/build_exe.sh --clean --yes
 
       - name: Package Linux artifact
-        run: tar -czf "dist/Wisp-${GITHUB_REF_NAME}-linux-x64.tar.gz" -C dist Wisp
+        run: |
+          safe_ref="${GITHUB_REF_NAME//\//-}"
+          tar -czf "dist/Wisp-${safe_ref}-linux-x64.tar.gz" -C dist Wisp
 
       - name: Upload Linux release asset
         if: startsWith(github.ref, 'refs/tags/v')
@@ -155,7 +159,8 @@ jobs:
         run: |
           arch="$(uname -m)"
           if [ "$arch" = "x86_64" ]; then arch="x64"; fi
-          ditto -c -k --keepParent dist/Wisp.app "dist/Wisp-${GITHUB_REF_NAME}-macos-${arch}.zip"
+          safe_ref="${GITHUB_REF_NAME//\//-}"
+          ditto -c -k --keepParent dist/Wisp.app "dist/Wisp-${safe_ref}-macos-${arch}.zip"
 
       - name: Upload macOS release asset
         if: startsWith(github.ref, 'refs/tags/v')

--- a/README.es.md
+++ b/README.es.md
@@ -15,6 +15,8 @@ Wisp te da IA controlada por atajos de teclado que puede leer tu selección, por
 
 **Idiomas:** [English](README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [Français](README.fr.md) | Español
 
+**Sitio web:** [Documentación de Wisp](https://sunnylich.github.io/Python-AI-assistant-overlay/)
+
 [Inicio rápido](#inicio-rápido) | [Qué hace](#qué-hace-wisp) | [Demos](#demos) | [Configuración](#configuración) | [APIs gratuitas](#fuentes-de-api-de-modelos-gratuitas) | [Privacidad](#privacidad-y-control)
 
 ![Demo Wisp Ctrl+Q](ReadMe%201st%20Demo.gif)

--- a/README.fr.md
+++ b/README.fr.md
@@ -15,6 +15,8 @@ Wisp vous offre une IA pilotée par raccourcis clavier qui peut lire votre séle
 
 **Langues :** [English](README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | Français | [Español](README.es.md)
 
+**Site web :** [Documentation Wisp](https://sunnylich.github.io/Python-AI-assistant-overlay/)
+
 [Démarrage rapide](#démarrage-rapide) | [Fonctionnalités](#ce-que-fait-wisp) | [Démos](#démos) | [Configuration](#configuration) | [APIs gratuites](#sources-dapi-de-modèles-gratuites) | [Confidentialité](#confidentialité-et-contrôle)
 
 ![Démo Wisp Ctrl+Q](ReadMe%201st%20Demo.gif)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Wisp gives you hotkey-driven AI that can read your selection, clipboard, app, br
 
 **Languages:** English | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [Français](README.fr.md) | [Español](README.es.md)
 
+**Website:** [Wisp Docs](https://sunnylich.github.io/Python-AI-assistant-overlay/)
+
 [Quick start](#quick-start) | [What it does](#what-wisp-does) | [Demos](#demos) | [Configuration](#configuration) | [Free APIs](#free-model-api-sources) | [Privacy](#privacy-and-control)
 
 ![Wisp Ctrl+Q demo](ReadMe%201st%20Demo.gif)

--- a/README.md
+++ b/README.md
@@ -112,6 +112,18 @@ Use this if you want the app without cloning the repo or managing Python depende
 | macOS | `Wisp-<tag>-macos-<arch>.zip` | `Wisp.app` |
 | Linux | `Wisp-<tag>-linux-x64.tar.gz` | `Wisp` |
 
+Release pages include `SHA256SUMS.txt` so you can verify the archive after
+download. On Windows, run:
+
+```powershell
+Get-FileHash .\Wisp-<tag>-windows-x64.zip -Algorithm SHA256
+```
+
+Compare the hash with the matching line in `SHA256SUMS.txt`. Windows may still
+show a SmartScreen warning for unsigned builds from an independent open-source
+publisher; the checksum confirms the file matches the release asset uploaded by
+the project.
+
 ### Option 2: Repo Launcher
 
 Use this if you want to run from source, develop Wisp, or test the latest checkout.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -15,6 +15,8 @@ Wisp 为您提供快捷键驱动的 AI，能够读取您的选中内容、剪贴
 
 **语言：** [English](README.md) | 简体中文 | [繁體中文](README.zh-TW.md) | [Français](README.fr.md) | [Español](README.es.md)
 
+**网站：** [Wisp 文档](https://sunnylich.github.io/Python-AI-assistant-overlay/)
+
 [快速开始](#快速开始) | [功能介绍](#wisp-的功能) | [演示](#演示) | [配置](#配置) | [免费 API](#免费模型-api-来源) | [隐私](#隐私与控制)
 
 ![Wisp Ctrl+Q 演示](ReadMe%201st%20Demo.gif)

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -15,6 +15,8 @@ Wisp 為您提供快捷鍵驅動的 AI，能夠讀取您的選取內容、剪貼
 
 **語言：** [English](README.md) | [简体中文](README.zh-CN.md) | 繁體中文 | [Français](README.fr.md) | [Español](README.es.md)
 
+**網站：** [Wisp 文件](https://sunnylich.github.io/Python-AI-assistant-overlay/)
+
 [快速開始](#快速開始) | [功能介紹](#wisp-的功能) | [示範](#示範) | [設定](#設定) | [免費 API](#免費模型-api-來源) | [隱私](#隱私與控制)
 
 ![Wisp Ctrl+Q 示範](ReadMe%201st%20Demo.gif)

--- a/assets/updater/windows_apply_update.ps1
+++ b/assets/updater/windows_apply_update.ps1
@@ -1,0 +1,38 @@
+param(
+    [Parameter(Mandatory = $true)][string]$Archive,
+    [Parameter(Mandatory = $true)][string]$InstallRoot,
+    [Parameter(Mandatory = $true)][string]$Candidate,
+    [Parameter(Mandatory = $true)][string]$RestartTarget,
+    [Parameter(Mandatory = $true)][string]$BackupRoot,
+    [Parameter(Mandatory = $true)][string]$WorkRoot,
+    [Parameter(Mandatory = $false)][string]$SingleInstanceLock = ""
+)
+
+$ErrorActionPreference = "Stop"
+$ErrorLog = Join-Path (Split-Path -LiteralPath $Archive -Parent) "apply-update-error.log"
+
+function Restore-Backup {
+    if ((Test-Path -LiteralPath $BackupRoot) -and -not (Test-Path -LiteralPath $InstallRoot)) {
+        Rename-Item -LiteralPath $BackupRoot -NewName (Split-Path -Leaf $InstallRoot)
+    }
+}
+
+try {
+    if (-not (Test-Path -LiteralPath $Candidate)) {
+        throw "Could not find the extracted Wisp app folder."
+    }
+    if (Test-Path -LiteralPath $BackupRoot) {
+        Remove-Item -LiteralPath $BackupRoot -Recurse -Force
+    }
+    Rename-Item -LiteralPath $InstallRoot -NewName (Split-Path -Leaf $BackupRoot)
+    Move-Item -LiteralPath $Candidate -Destination $InstallRoot
+    Start-Process -FilePath $RestartTarget -WorkingDirectory (Split-Path -LiteralPath $RestartTarget -Parent)
+    Start-Sleep -Seconds 5
+    Remove-Item -LiteralPath $BackupRoot -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $WorkRoot -Recurse -Force -ErrorAction SilentlyContinue
+    exit 0
+} catch {
+    Restore-Backup
+    $_ | Out-String | Set-Content -LiteralPath $ErrorLog
+    exit 1
+}

--- a/core/updater.py
+++ b/core/updater.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Any
 
-from core.system.paths import UPDATE_DOWNLOAD_DIR
+from core.system.paths import SINGLE_INSTANCE_LOCK, UPDATE_DOWNLOAD_DIR
 
 DEFAULT_MANIFEST_URL = (
     "https://github.com/SunnyLich/Python-AI-assistant-overlay/"
@@ -264,6 +264,7 @@ $pidToWait = {pid}
 $archive = {_quoted_ps(str(update_path))}
 $installRoot = {_quoted_ps(str(root))}
 $restartTarget = {_quoted_ps(str(restart_target))}
+$singleInstanceLock = {_quoted_ps(str(SINGLE_INSTANCE_LOCK))}
 $archiveRootName = {_quoted_ps(archive_root)}
 $workRoot = Join-Path (Split-Path -LiteralPath $archive -Parent) ("apply-" + [guid]::NewGuid().ToString())
 $extractRoot = Join-Path $workRoot "extract"
@@ -275,9 +276,188 @@ function Restore-Backup {{
     }}
 }}
 
-try {{
-    New-Item -ItemType Directory -Force -Path $extractRoot | Out-Null
+function Initialize-InstallerUi {{
+    try {{
+        Add-Type -AssemblyName System.Windows.Forms
+        Add-Type -AssemblyName System.Drawing
+        $script:form = New-Object System.Windows.Forms.Form
+        $script:form.Text = "Wisp Update"
+        $script:form.Width = 440
+        $script:form.Height = 190
+        $script:form.StartPosition = "CenterScreen"
+        $script:form.FormBorderStyle = "FixedDialog"
+        $script:form.MaximizeBox = $false
+        $script:form.MinimizeBox = $true
+        $script:form.TopMost = $true
+        try {{
+            $script:form.Icon = [System.Drawing.Icon]::ExtractAssociatedIcon($restartTarget)
+        }} catch {{ }}
+
+        $title = New-Object System.Windows.Forms.Label
+        $title.Text = "Updating Wisp"
+        $title.Font = New-Object System.Drawing.Font($title.Font.FontFamily, 12, [System.Drawing.FontStyle]::Bold)
+        $title.Left = 20
+        $title.Top = 18
+        $title.Width = 380
+        $title.Height = 26
+        $script:form.Controls.Add($title)
+
+        $script:statusLabel = New-Object System.Windows.Forms.Label
+        $script:statusLabel.Text = "Preparing update..."
+        $script:statusLabel.Left = 20
+        $script:statusLabel.Top = 54
+        $script:statusLabel.Width = 390
+        $script:statusLabel.Height = 34
+        $script:form.Controls.Add($script:statusLabel)
+
+        $script:progress = New-Object System.Windows.Forms.ProgressBar
+        $script:progress.Left = 20
+        $script:progress.Top = 95
+        $script:progress.Width = 390
+        $script:progress.Height = 18
+        $script:progress.Style = "Marquee"
+        $script:progress.MarqueeAnimationSpeed = 35
+        $script:form.Controls.Add($script:progress)
+
+        $script:closeButton = New-Object System.Windows.Forms.Button
+        $script:closeButton.Text = "Close"
+        $script:closeButton.Left = 320
+        $script:closeButton.Top = 122
+        $script:closeButton.Width = 90
+        $script:closeButton.Visible = $false
+        $script:closeButton.Add_Click({{ $script:form.Close() }})
+        $script:form.Controls.Add($script:closeButton)
+
+        $script:form.Show()
+        [System.Windows.Forms.Application]::DoEvents()
+    }} catch {{
+        $script:form = $null
+    }}
+}}
+
+function Update-InstallerStatus {{
+    param([string]$Message)
+    try {{
+        if ($script:statusLabel -ne $null) {{
+            $script:statusLabel.Text = $Message
+            [System.Windows.Forms.Application]::DoEvents()
+        }}
+    }} catch {{ }}
+}}
+
+function Finish-InstallerUi {{
+    param(
+        [string]$Message,
+        [bool]$Failed
+    )
+    try {{
+        if ($script:form -eq $null) {{
+            return
+        }}
+        if ($script:progress -ne $null) {{
+            $script:progress.Style = "Blocks"
+            $script:progress.MarqueeAnimationSpeed = 0
+            $script:progress.Value = $(if ($Failed) {{ 0 }} else {{ 100 }})
+        }}
+        if ($script:statusLabel -ne $null) {{
+            $script:statusLabel.Text = $Message
+        }}
+        if ($Failed) {{
+            $script:form.TopMost = $false
+            $script:closeButton.Visible = $true
+            $script:form.Activate()
+            while ($script:form.Visible) {{
+                [System.Windows.Forms.Application]::DoEvents()
+                Start-Sleep -Milliseconds 100
+            }}
+        }} else {{
+            [System.Windows.Forms.Application]::DoEvents()
+            Start-Sleep -Milliseconds 500
+            $script:form.Close()
+        }}
+    }} catch {{ }}
+}}
+
+function Test-WispLockReleased {{
+    $stream = $null
+    try {{
+        $parent = Split-Path -LiteralPath $singleInstanceLock -Parent
+        if ($parent -and -not (Test-Path -LiteralPath $parent)) {{
+            New-Item -ItemType Directory -Force -Path $parent | Out-Null
+        }}
+        $stream = [System.IO.File]::Open($singleInstanceLock, [System.IO.FileMode]::OpenOrCreate, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::ReadWrite)
+        $stream.Lock(0, 1)
+        $stream.Unlock(0, 1)
+        return $true
+    }} catch {{
+        return $false
+    }} finally {{
+        if ($stream -ne $null) {{
+            $stream.Dispose()
+        }}
+    }}
+}}
+
+function Wait-For-WispExit {{
+    Update-InstallerStatus "Waiting for Wisp to close..."
     try {{ Wait-Process -Id $pidToWait -Timeout 90 -ErrorAction SilentlyContinue }} catch {{ }}
+    $deadline = (Get-Date).AddMinutes(5)
+    while ((Get-Date) -lt $deadline) {{
+        if (Test-WispLockReleased) {{
+            Start-Sleep -Seconds 1
+            return
+        }}
+        Start-Sleep -Seconds 1
+    }}
+    throw "Timed out waiting for Wisp to exit before applying the update."
+}}
+
+function Find-NewVersionHelper {{
+    param([string]$CandidateRoot)
+    $relativePaths = @(
+        "_internal\\assets\\updater\\windows_apply_update.ps1",
+        "assets\\updater\\windows_apply_update.ps1",
+        "updater\\windows_apply_update.ps1"
+    )
+    foreach ($relativePath in $relativePaths) {{
+        $helper = Join-Path $CandidateRoot $relativePath
+        if (Test-Path -LiteralPath $helper -PathType Leaf) {{
+            return $helper
+        }}
+    }}
+    return $null
+}}
+
+function Invoke-NewVersionHelper {{
+    param(
+        [string]$Helper,
+        [string]$Candidate
+    )
+    $delegatedHelper = Join-Path (Split-Path -LiteralPath $archive -Parent) ("apply-new-wisp-update-" + [guid]::NewGuid().ToString() + ".ps1")
+    Copy-Item -LiteralPath $Helper -Destination $delegatedHelper -Force
+    Update-InstallerStatus "Starting the newer installer..."
+    & powershell -NoProfile -ExecutionPolicy Bypass -File $delegatedHelper `
+        -Archive $archive `
+        -InstallRoot $installRoot `
+        -Candidate $Candidate `
+        -RestartTarget $restartTarget `
+        -BackupRoot $backupRoot `
+        -WorkRoot $workRoot `
+        -SingleInstanceLock $singleInstanceLock
+    $exitCode = $LASTEXITCODE
+    Remove-Item -LiteralPath $delegatedHelper -Force -ErrorAction SilentlyContinue
+    if ($exitCode -ne 0) {{
+        throw "The newer Wisp installer failed with exit code $exitCode."
+    }}
+}}
+
+Initialize-InstallerUi
+
+try {{
+    Update-InstallerStatus "Preparing update files..."
+    New-Item -ItemType Directory -Force -Path $extractRoot | Out-Null
+    Wait-For-WispExit
+    Update-InstallerStatus "Extracting the downloaded update..."
     Expand-Archive -LiteralPath $archive -DestinationPath $extractRoot -Force
     $candidate = Join-Path $extractRoot $archiveRootName
     if (-not (Test-Path -LiteralPath $candidate)) {{
@@ -288,19 +468,29 @@ try {{
             throw "Could not find the extracted Wisp app folder."
         }}
     }}
+    $newVersionHelper = Find-NewVersionHelper $candidate
+    if ($newVersionHelper) {{
+        Invoke-NewVersionHelper -Helper $newVersionHelper -Candidate $candidate
+        Finish-InstallerUi "Wisp has been updated and reopened." $false
+        exit 0
+    }}
+    Update-InstallerStatus "Replacing the old Wisp files..."
     if (Test-Path -LiteralPath $backupRoot) {{
         Remove-Item -LiteralPath $backupRoot -Recurse -Force
     }}
     Rename-Item -LiteralPath $installRoot -NewName (Split-Path -Leaf $backupRoot)
     Move-Item -LiteralPath $candidate -Destination $installRoot
+    Update-InstallerStatus "Reopening Wisp..."
     Start-Process -FilePath $restartTarget -WorkingDirectory (Split-Path -LiteralPath $restartTarget -Parent)
     Start-Sleep -Seconds 5
     Remove-Item -LiteralPath $backupRoot -Recurse -Force -ErrorAction SilentlyContinue
     Remove-Item -LiteralPath $workRoot -Recurse -Force -ErrorAction SilentlyContinue
+    Finish-InstallerUi "Wisp has been updated and reopened." $false
 }} catch {{
     Restore-Backup
     $log = Join-Path (Split-Path -LiteralPath $archive -Parent) "apply-update-error.log"
     $_ | Out-String | Set-Content -LiteralPath $log
+    Finish-InstallerUi "Wisp update failed. Details were saved to $log" $true
     exit 1
 }}
 """
@@ -322,10 +512,12 @@ pid_to_wait={pid}
 archive={_quoted_sh(str(update_path))}
 install_root={_quoted_sh(str(root))}
 restart_target={_quoted_sh(str(restart_target))}
+single_instance_lock={_quoted_sh(str(SINGLE_INSTANCE_LOCK))}
 archive_root_name={_quoted_sh(archive_root)}
 work_root="$(dirname "$archive")/apply-$(date +%s)-$$"
 extract_root="$work_root/extract"
 backup_root="$install_root.previous-update"
+error_log="$(dirname "$archive")/apply-update-error.log"
 
 restore_backup() {{
     if [ -d "$backup_root" ] && [ ! -e "$install_root" ]; then
@@ -333,18 +525,37 @@ restore_backup() {{
     fi
 }}
 
-trap 'rc=$?; if [ "$rc" -ne 0 ]; then restore_backup; echo "Wisp update apply failed." > "$(dirname "$archive")/apply-update-error.log"; fi; exit "$rc"' EXIT
+wait_for_wisp_exit() {{
+    while kill -0 "$pid_to_wait" 2>/dev/null; do
+        sleep 1
+    done
+    if command -v flock >/dev/null 2>&1; then
+        deadline=$(( $(date +%s) + 300 ))
+        while [ "$(date +%s)" -lt "$deadline" ]; do
+            mkdir -p "$(dirname "$single_instance_lock")"
+            if (
+                flock -n 9
+            ) 9>"$single_instance_lock"; then
+                sleep 1
+                return 0
+            fi
+            sleep 1
+        done
+        echo "Timed out waiting for Wisp to exit before applying the update." > "$error_log"
+        exit 1
+    fi
+}}
+
+trap 'rc=$?; if [ "$rc" -ne 0 ]; then restore_backup; if [ ! -s "$error_log" ]; then echo "Wisp update apply failed." > "$error_log"; fi; fi; exit "$rc"' EXIT
 mkdir -p "$extract_root"
-while kill -0 "$pid_to_wait" 2>/dev/null; do
-    sleep 1
-done
+wait_for_wisp_exit
 {extract_command}
 candidate="$extract_root/$archive_root_name"
 if [ ! -e "$candidate" ]; then
     candidate="$(find "$extract_root" -mindepth 1 -maxdepth 1 -type d | head -n 1)"
 fi
 if [ -z "$candidate" ] || [ ! -e "$candidate" ]; then
-    echo "Could not find the extracted Wisp app folder." > "$(dirname "$archive")/apply-update-error.log"
+    echo "Could not find the extracted Wisp app folder." > "$error_log"
     exit 1
 fi
 rm -rf "$backup_root"
@@ -359,6 +570,16 @@ rm -rf "$backup_root" "$work_root"
     return script_path
 
 
+def _update_wait_pid(pid: int | None = None) -> int:
+    """Return the process the helper should wait for before replacing files."""
+    if pid is not None:
+        return pid
+    supervisor_pid = str(os.environ.get("WISP_SUPERVISOR_PID") or "").strip()
+    if supervisor_pid.isdigit() and int(supervisor_pid) > 0:
+        return int(supervisor_pid)
+    return os.getpid()
+
+
 def apply_update(update_path: Path, pid: int | None = None) -> Path:
     """Start a detached helper that applies an update after Wisp exits."""
     update_path = Path(update_path).resolve()
@@ -366,7 +587,7 @@ def apply_update(update_path: Path, pid: int | None = None) -> Path:
         raise UpdateError("Downloaded update file is no longer available.")
     root = install_root()
     restart_target = Path(sys.executable).resolve()
-    wait_pid = pid or os.getpid()
+    wait_pid = _update_wait_pid(pid)
     UPDATE_DOWNLOAD_DIR.mkdir(parents=True, exist_ok=True)
 
     if sys.platform == "win32":
@@ -380,6 +601,7 @@ def apply_update(update_path: Path, pid: int | None = None) -> Path:
             [
                 "powershell",
                 "-NoProfile",
+                "-STA",
                 "-ExecutionPolicy",
                 "Bypass",
                 "-File",

--- a/docs/BUILDING_EXE.md
+++ b/docs/BUILDING_EXE.md
@@ -91,11 +91,12 @@ The workflow builds:
 - Linux: `Wisp-<tag>-linux-x64.tar.gz`
 
 After all platform jobs finish, the workflow creates or updates a draft GitHub
-Release and uploads `wisp-release-manifest.json`. The Settings update button
-uses that manifest to find the newest build for the current platform, verify
-the SHA256 hash, download the matching artifact, and then apply it through a
-small helper process when the user chooses **Apply update**. The helper waits
-for Wisp to exit, replaces the packaged app folder, and restarts Wisp.
+Release and uploads `wisp-release-manifest.json` plus `SHA256SUMS.txt`. The
+Settings update button uses the manifest to find the newest build for the
+current platform, verify the SHA256 hash, download the matching artifact, and
+then apply it through a small helper process when the user chooses **Apply
+update**. Users can compare downloaded archives against `SHA256SUMS.txt` from
+the release page before unpacking them.
 
 Manual platform build entry points:
 

--- a/runtime/supervisor/ipc.py
+++ b/runtime/supervisor/ipc.py
@@ -88,6 +88,7 @@ class WorkerClient:
         env.update(self.spec.env)
         env.setdefault("PYTHONUNBUFFERED", "1")
         env.setdefault("WISP_REPO_ROOT", str(data_root()))
+        env.setdefault("WISP_SUPERVISOR_PID", str(os.getpid()))
         self._stderr_log_path = self._worker_log_path(env)
         log.info("starting %s: %s", self.spec.name, self.spec.module)
         if self._stderr_log_path is not None:

--- a/scripts/make_release_manifest.py
+++ b/scripts/make_release_manifest.py
@@ -55,17 +55,27 @@ def build_manifest(asset_paths: list[Path], repo: str, tag: str) -> dict:
     }
 
 
+def build_checksums(asset_paths: list[Path]) -> str:
+    """Build a sha256sum-compatible checksum listing for release assets."""
+    lines = [f"{_sha256(path)}  {path.name}" for path in sorted(asset_paths, key=lambda item: item.name)]
+    return "\n".join(lines) + "\n"
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--repo", required=True, help="GitHub repository, e.g. owner/name")
     parser.add_argument("--tag", required=True, help="Release tag, e.g. v0.6 or v0.6.1")
     parser.add_argument("--out", required=True, type=Path)
+    parser.add_argument("--checksums-out", type=Path, help="Optional SHA256SUMS.txt output path")
     parser.add_argument("assets", nargs="+", type=Path)
     args = parser.parse_args()
 
     manifest = build_manifest(args.assets, repo=args.repo, tag=args.tag)
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if args.checksums_out:
+        args.checksums_out.parent.mkdir(parents=True, exist_ok=True)
+        args.checksums_out.write_text(build_checksums(args.assets), encoding="utf-8")
     return 0
 
 

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -59,7 +59,11 @@ class GitHubWorkflowTests(unittest.TestCase):
         self.assertIn("Upload Windows release asset", workflow)
         self.assertIn("Upload Linux release asset", workflow)
         self.assertIn("Upload macOS release asset", workflow)
-        self.assertIn('gh release upload "$GITHUB_REF_NAME" release-assets/wisp-release-manifest.json --clobber', workflow)
+        self.assertIn("--checksums-out release-assets/SHA256SUMS.txt", workflow)
+        self.assertIn(
+            'gh release upload "$GITHUB_REF_NAME" release-assets/wisp-release-manifest.json release-assets/SHA256SUMS.txt --clobber',
+            workflow,
+        )
 
     def test_build_workflow_sanitizes_manual_artifact_branch_names(self) -> None:
         workflow = (ROOT / ".github" / "workflows" / "build.yml").read_text(encoding="utf-8")

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -61,6 +61,15 @@ class GitHubWorkflowTests(unittest.TestCase):
         self.assertIn("Upload macOS release asset", workflow)
         self.assertIn('gh release upload "$GITHUB_REF_NAME" release-assets/wisp-release-manifest.json --clobber', workflow)
 
+    def test_build_workflow_sanitizes_manual_artifact_branch_names(self) -> None:
+        workflow = (ROOT / ".github" / "workflows" / "build.yml").read_text(encoding="utf-8")
+
+        self.assertIn("$safeRef = $env:GITHUB_REF_NAME -replace", workflow)
+        self.assertIn("Wisp-$safeRef-windows-x64.zip", workflow)
+        self.assertIn('safe_ref="${GITHUB_REF_NAME//\\//-}"', workflow)
+        self.assertIn("Wisp-${safe_ref}-linux-x64.tar.gz", workflow)
+        self.assertIn("Wisp-${safe_ref}-macos-${arch}.zip", workflow)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -46,3 +46,17 @@ def test_release_manifest_rejects_non_version_tag(tmp_path: Path) -> None:
             repo="SunnyLich/Python-AI-assistant-overlay",
             tag="latest",
         )
+
+
+def test_build_checksums_lists_release_assets_by_name(tmp_path: Path) -> None:
+    windows_asset = tmp_path / "Wisp-v0.6.1-windows-x64.zip"
+    linux_asset = tmp_path / "Wisp-v0.6.1-linux-x64.tar.gz"
+    windows_asset.write_bytes(b"windows")
+    linux_asset.write_bytes(b"linux")
+
+    checksums = make_release_manifest.build_checksums([windows_asset, linux_asset])
+
+    assert checksums == (
+        f"{make_release_manifest._sha256(linux_asset)}  {linux_asset.name}\n"
+        f"{make_release_manifest._sha256(windows_asset)}  {windows_asset.name}\n"
+    )

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -91,6 +91,7 @@ def test_apply_update_writes_windows_helper_without_running_it(monkeypatch, tmp_
     monkeypatch.setattr(sys, "platform", "win32")
     monkeypatch.setattr(sys, "executable", str(executable))
     monkeypatch.setattr(updater, "UPDATE_DOWNLOAD_DIR", updates_dir)
+    monkeypatch.setattr(updater, "SINGLE_INSTANCE_LOCK", tmp_path / "wisp.lock")
     monkeypatch.setattr(updater.subprocess, "Popen", fake_popen)
 
     script = updater.apply_update(update, pid=123)
@@ -99,13 +100,91 @@ def test_apply_update_writes_windows_helper_without_running_it(monkeypatch, tmp_
     assert script.parent == updates_dir
     script_text = script.read_text(encoding="utf-8")
     assert "Wait-Process -Id $pidToWait" in script_text
+    assert "System.Windows.Forms.Form" in script_text
+    assert "[System.Drawing.Icon]::ExtractAssociatedIcon($restartTarget)" in script_text
+    assert "Updating Wisp" in script_text
+    assert "Find-NewVersionHelper" in script_text
+    assert "windows_apply_update.ps1" in script_text
+    assert "Starting the newer installer..." in script_text
+    assert "Test-WispLockReleased" in script_text
+    assert "$singleInstanceLock" in script_text
+    assert "Wait-For-WispExit" in script_text
     assert "Expand-Archive" in script_text
     assert "$archiveRootName = 'Wisp'" in script_text
-    assert launched["cmd"][:5] == [
+    assert launched["cmd"][:6] == [
         "powershell",
         "-NoProfile",
+        "-STA",
         "-ExecutionPolicy",
         "Bypass",
         "-File",
     ]
     assert launched["cmd"][-1] == str(script)
+
+
+def test_apply_update_writes_posix_helper_with_lock_wait(monkeypatch, tmp_path: Path) -> None:
+    update = tmp_path / "Wisp-test-linux-x64.zip"
+    with zipfile.ZipFile(update, "w") as archive:
+        archive.writestr("Wisp/Wisp", "new executable")
+
+    executable = tmp_path / "CurrentWisp" / "Wisp"
+    executable.parent.mkdir()
+    executable.write_text("current executable", encoding="utf-8")
+    updates_dir = tmp_path / "updates"
+    launched: dict[str, object] = {}
+
+    def fake_popen(cmd, **kwargs):
+        launched["cmd"] = cmd
+        launched["kwargs"] = kwargs
+        return SimpleNamespace(pid=456)
+
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(sys, "executable", str(executable))
+    monkeypatch.setattr(updater, "UPDATE_DOWNLOAD_DIR", updates_dir)
+    monkeypatch.setattr(updater, "SINGLE_INSTANCE_LOCK", tmp_path / "wisp.lock")
+    monkeypatch.setattr(updater.subprocess, "Popen", fake_popen)
+
+    script = updater.apply_update(update, pid=123)
+
+    assert script.exists()
+    assert script.parent == updates_dir
+    script_text = script.read_text(encoding="utf-8")
+    assert "wait_for_wisp_exit" in script_text
+    assert "single_instance_lock=" in script_text
+    assert "flock -n 9" in script_text
+    assert "Timed out waiting for Wisp to exit before applying the update." in script_text
+    assert launched["cmd"] == [str(script)]
+    assert launched["kwargs"]["start_new_session"] is True
+
+
+def test_apply_update_prefers_supervisor_pid_from_environment(monkeypatch, tmp_path: Path) -> None:
+    update = tmp_path / "Wisp-test-windows-x64.zip"
+    with zipfile.ZipFile(update, "w") as archive:
+        archive.writestr("Wisp/Wisp.exe", "new exe")
+
+    executable = tmp_path / "CurrentWisp" / "Wisp.exe"
+    executable.parent.mkdir()
+    executable.write_text("current exe", encoding="utf-8")
+
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(sys, "executable", str(executable))
+    monkeypatch.setattr(updater, "UPDATE_DOWNLOAD_DIR", tmp_path / "updates")
+    monkeypatch.setattr(updater, "SINGLE_INSTANCE_LOCK", tmp_path / "wisp.lock")
+    monkeypatch.setattr(updater.subprocess, "Popen", lambda *args, **kwargs: SimpleNamespace(pid=456))
+    monkeypatch.setenv("WISP_SUPERVISOR_PID", "9876")
+
+    script = updater.apply_update(update)
+
+    assert "$pidToWait = 9876" in script.read_text(encoding="utf-8")
+
+
+def test_windows_new_version_helper_asset_is_bundled() -> None:
+    helper = Path("assets/updater/windows_apply_update.ps1")
+
+    assert helper.exists()
+    text = helper.read_text(encoding="utf-8")
+    assert "[Parameter(Mandatory = $true)][string]$Candidate" in text
+    assert "Move-Item -LiteralPath $Candidate -Destination $InstallRoot" in text
+    assert "Start-Process -FilePath $RestartTarget" in text

--- a/ui/settings_panel/dialog.py
+++ b/ui/settings_panel/dialog.py
@@ -4252,10 +4252,13 @@ class SettingsDialog(QDialog):
             self._update_mode = "apply"
             self._update_btn.setEnabled(False)
             self._update_btn.setText(t("Applying..."))
-            self._set_update_status("Applying update. Wisp will restart shortly.", "ok")
+            self._set_update_status(
+                "Applying update. Wisp will close now; installing and reopening can take a few minutes.",
+                "ok",
+            )
             app = QApplication.instance()
             if app is not None:
-                QTimer.singleShot(250, app.quit)
+                QTimer.singleShot(1500, app.quit)
         except Exception as exc:  # noqa: BLE001 - surface launcher issues in Settings
             self._set_update_status("Could not apply update: {error}", "error", error=exc)
 


### PR DESCRIPTION
## Summary
- show a visible Windows updater window with Wisp icon and progress while applying updates
- bundle a newer-version Windows apply helper for future update delegation
- wait for the supervisor/app lock before replacing packaged files

## Validation
- python -m pytest tests\\test_updater.py --basetemp .pytest_tmp
- python -m compileall core\\updater.py runtime\\supervisor\\ipc.py ui\\settings_panel\\dialog.py
- PowerShell parser check for assets/updater/windows_apply_update.ps1